### PR TITLE
add "is copy"

### DIFF
--- a/lib/Router/Boost.pm6
+++ b/lib/Router/Boost.pm6
@@ -96,7 +96,7 @@ method add(Router::Boost:D: Str $path, $stuff) {
     $node.leaf = [[@capture], $stuff];
 }
 
-method match(Router::Boost:D: Str $path) {
+method match(Router::Boost:D: Str $path is copy) {
     $path = '/' if $path eq '';
 
     my $regexp = self!regexp;


### PR DESCRIPTION
I encountered the following error. This PR fixes this.

```
Cannot assign to an immutable value
  in method match at /Users/skaji/env/rakudobrew/moar-nom/install/share/perl6/site/lib/Router/Boost.pm6:100
```
