### PR TITLE
use MONKEY-SEE-NO-EVAL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /src/*.o
 /src/Makefile
 /.panda-work
+.precomp/

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ install:
   - panda --notests installdeps .
 script:
   - perl6 -MPanda::Builder -e 'Panda::Builder.build(~$*CWD)'
-  - PERL6LIB=$PWD/blib/lib prove -e perl6 -rv t/
+  - PERL6LIB=$PWD/lib prove -e perl6 -rv t/
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ install:
   - rakudobrew build-panda
   - panda --notests installdeps .
 script:
-  - perl6 -MPanda::Builder -e 'Panda::Builder.build($*CWD)'
+  - perl6 -MPanda::Builder -e 'Panda::Builder.build(~$*CWD)'
   - PERL6LIB=$PWD/blib/lib prove -e perl6 -rv t/
 sudo: false

--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,8 @@
 {
   "name" : "Router::Boost",
   "source-url" : "git://github.com/moznion/p6-Router-Boost.git",
-  "perl" : "v6",
+  "perl" : "6.c",
+  "resources" : [ ],
   "build-depends" : [ ],
   "provides" : {
     "Router::Boost" : "lib/Router/Boost.pm6",

--- a/lib/Router/Boost.pm6
+++ b/lib/Router/Boost.pm6
@@ -1,5 +1,6 @@
 use v6;
 use Router::Boost::Node;
+use MONKEY-SEE-NO-EVAL; # suppress "Prohibited regex interpolation"
 
 unit class Router::Boost;
 


### PR DESCRIPTION
Currently tests fail with latest rakudo. Please look at https://gist.github.com/skaji/1d9b772c60e5b70d3d09

This is because the following code is no longer vaild unless we specify `use MONKEY-SEE-NO-EVAL`
just like `use re 'eval'` in perl5:

```
> cat test.p6
my $re = q{${ say "hey" }};
"foo" ~~ /<$re>/;

> perl6 test.p6
===SORRY!=== Error while compiling /Users/skaji/EVAL_0
Prohibited regex interpolation (use MONKEY-SEE-NO-EVAL to override,
but only if you're VERY sure your data contains no injection attacks)
at /Users/skaji/EVAL_0:1
```

This PR
- use MONKEY-SEE-NO-EVAL to suppress "Prohibited regex interpolation" ff40afc
- tweak meta files to follow latest rakudo and panda changes 50a4e1a
